### PR TITLE
Add URL Scheme if missing

### DIFF
--- a/Classes/Domain/Validator/StringValidator.php
+++ b/Classes/Domain/Validator/StringValidator.php
@@ -40,7 +40,13 @@ class StringValidator extends AbstractValidator {
 	 * @return bool
 	 */
 	protected function validateUrl($value) {
-		if (filter_var($value, FILTER_VALIDATE_URL) !== FALSE) {
+		if ( $parts = parse_url($value) ) {
+			if ( !isset($parts["scheme"]) )
+			{
+				$value = "http://$value";
+			}
+		}
+		if (filter_var($value, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED | FILTER_FLAG_HOST_REQUIRED) !== FALSE) {
 			return TRUE;
 		};
 		return FALSE;


### PR DESCRIPTION
If you have parsley js validation enabled. it says ok for urls like these 'example.com' 'www.example.com'.
But after submitting the form  php validation says: 'not a valid url' because its missing the scheme part.

here I have added the scheme if its missing.