### PR TITLE
Update tx_powermail_domain_model_mails.php

### DIFF
--- a/Configuration/TCA/tx_powermail_domain_model_mails.php
+++ b/Configuration/TCA/tx_powermail_domain_model_mails.php
@@ -191,7 +191,9 @@ $mailsTca = array(
 						'type' => 'script',
 						'title' => 'RTE',
 						'icon' => 'wizard_rte2.gif',
-						'script' => 'wizard_rte.php',
+						'module' => array(
+			                            'name' => 'wizard_rte'
+			                        )
 					),
 				),
 			),


### PR DESCRIPTION
Defining wizards with 'script' is deprecated since TYPO3 6.2. To get it work in TYPO3 7.4 use 'module' => 'name'.
https://docs.typo3.org/typo3cms/TCAReference/AdditionalFeatures/CoreWizardScripts/Index.html