### PR TITLE
[TASK] Fix email not being saved to database

### DIFF
--- a/pi1/class.tx_powermail_submit.php
+++ b/pi1/class.tx_powermail_submit.php
@@ -348,7 +348,8 @@ class tx_powermail_submit extends tslib_pibase {
 				'senderIP' => ($this->confArr['disableIPlog'] == 1 ? $this->pi_getLL('error_backend_noip') : t3lib_div::getIndpEnv('REMOTE_ADDR')), // save users IP address
 				'UserAgent' => t3lib_div::getIndpEnv('HTTP_USER_AGENT'), // save user agent
 				'Referer' => t3lib_div::getIndpEnv('HTTP_REFERER'), // save referer
-				'SP_TZ' => $_SERVER['SP_TZ'] // save sp_tz if available
+				// cast value to string for sql table accepts NOT NULL values only
+				'SP_TZ' => (string)$_SERVER['SP_TZ'] // save sp_tz if available
 			);
 			if ($this->dbInsert) {
 				// DB entry


### PR DESCRIPTION
For $_SERVER['SP_TZ'] value being NULL the email is not saved to dabase because the mysql property accepts only NOT NULL values.
Therefore the value is being casted to string. The NULL value will then endup as empty string in the database.

I don't know what $_SERVER['SP_TZ'] is for. On our server the server var is not available.