### PR TITLE
[FEATURE] Add possibility to set addQueryString on form via TypoScript setup and constants

### DIFF
--- a/Configuration/TypoScript/Main/constants.txt
+++ b/Configuration/TypoScript/Main/constants.txt
@@ -192,6 +192,9 @@ plugin.tx_powermail {
 			# cat=powermail_additional//0808; type=boolean; label= AJAX Submit Form: Submit Powermail Forms with AJAX (browser will not reload complete page)
 			ajaxSubmit = 0
 
+			# cat=powermail_additional//0809; type=boolean; label= Enable AddQueryString to Form Action (e.g. to use powermail on a tx_news detail page)
+			addQueryString = 0
+
 			# cat=powermail_additional//0810; type=text; label= Misc Upload Folder: Define the folder where files should be uploaded with upload fields (e.g. fileadmin/uploads/)
 			uploadFolder = uploads/tx_powermail/
 

--- a/Configuration/TypoScript/Main/setup.txt
+++ b/Configuration/TypoScript/Main/setup.txt
@@ -368,6 +368,8 @@ plugin.tx_powermail {
 				# Submit Powermail Forms with AJAX (browser will not reload complete page)
 				ajaxSubmit = {$plugin.tx_powermail.settings.misc.ajaxSubmit}
 
+				addQueryString = {$plugin.tx_powermail.settings.misc.addQueryString}
+
 				# File upload settings
 				file {
 					folder = {$plugin.tx_powermail.settings.misc.uploadFolder}

--- a/Resources/Private/Templates/Form/Confirmation.html
+++ b/Resources/Private/Templates/Form/Confirmation.html
@@ -23,6 +23,7 @@ Show Confirmation Page
 				action="form"
 				name="field"
 				enctype="multipart/form-data"
+				addQueryString="{settings.misc.addQueryString}"
 				additionalAttributes="{vh:Validation.EnableParsleyAndAjax(form: mail.form)}">
 
 			<f:render section="HiddenFields" arguments="{_all}" />

--- a/Resources/Private/Templates/Form/Form.html
+++ b/Resources/Private/Templates/Form/Form.html
@@ -17,6 +17,7 @@ Render Powermail Form
 						name="field"
 						enctype="multipart/form-data"
 						additionalAttributes="{vh:Validation.EnableParsleyAndAjax(form:form)}"
+						addQueryString="{settings.misc.addQueryString}"
 						class="powermail_form powermail_form_{form.uid} {form.css} {vh:Misc.MorestepClass(activate:settings.main.moresteps, class:'powermail_morestep')}">
 
 					<h3>{form.title}</h3>


### PR DESCRIPTION
Just added a setting that let's you configure the addQueryString argument via TS. I see potential harm in just overwriting the template due to possible breaking changes introduced in newer versions of powermail.. had this numerous times before.. so this time you'll get a pull request ;-)