### PR TITLE
Global init ajax

### DIFF
--- a/Resources/Private/JavaScripts/Powermail/Form.js
+++ b/Resources/Private/JavaScripts/Powermail/Form.js
@@ -23,6 +23,10 @@ function PowermailForm($) {
 		uploadValidationListener();
 	};
 
+	this.externInitalize = function() {
+		addAjaxFormSubmitListener();
+	};
+
 	/**
 	 * Add tabs listener
 	 *
@@ -193,7 +197,7 @@ function PowermailForm($) {
 				redirectUri = $this.data('powermail-ajax-uri');
 			}
 			var formUid = $this.data('powermail-form');
-
+			
 			if (!regularSubmitOnAjax) {
 				$.ajax({
 					type: 'POST',
@@ -232,6 +236,7 @@ function PowermailForm($) {
 								$this.submit();
 							}
 							regularSubmitOnAjax = true;
+
 						}
 					}
 				});
@@ -486,6 +491,10 @@ function PowermailForm($) {
 
 jQuery(document).ready(function($) {
 	'use strict';
-	var PowermailForm = new window.PowermailForm($);
-	PowermailForm.initialize();
+	window.PowermailFormInstance = new window.PowermailForm($);
+	window.PowermailFormInstance.initialize();
 });
+
+window.initExtern = function() {
+	window.PowermailFormInstance.externInitalize();
+};

--- a/Resources/Private/Templates/Form/Confirmation.html
+++ b/Resources/Private/Templates/Form/Confirmation.html
@@ -74,4 +74,5 @@ Show Confirmation Page
 	</f:for>
 
 	<f:form.hidden name="mail[form]" value="{mail.form.uid}" class="powermail_form_uid" />
+	<input type="hidden" name="contentElementUid" value="{ttContentData.uid}">
 </f:section>

--- a/Resources/Private/Templates/Form/Form.html
+++ b/Resources/Private/Templates/Form/Form.html
@@ -28,6 +28,7 @@ Render Powermail Form
 					</f:for>
 
 					<f:form.hidden name="mail[form]" value="{form.uid}" class="powermail_form_uid" />
+					<input type="hidden" name="contentElementUid" value="{ttContentData.uid}">
 					<f:render partial="Misc/HoneyPod" arguments="{form:form}" />
 				</f:form>
 			</div>

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,29 @@
+{
+  "name": "punktde/powermail",
+  "type": "typo3-cms-extension",
+  "description": "Powermail by Alex Kellner, modified for Punkt.de",
+  "keywords": [
+    "TYPO3",
+    "extension"
+  ],
+  "license": [
+    "GPL-2.0+"
+  ],
+  "require": {
+    "typo3/cms-core": ">=6.2.0,<8.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "PunktDe\\powermail\\": "Classes"
+    },
+    "classmap": [
+      "Classes/"
+    ]
+  },
+  "extra": {
+    "typo3/cms": {
+      "cms-package-dir": "{$vendor-dir}/typo3/cms",
+      "web-dir": ".Build/Web"
+    }
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,10 @@
       "Classes/"
     ]
   },
+  "replace": {
+    "powermail": "self.version",
+    "typo3-ter/powermail": "self.version"
+  },
   "extra": {
     "typo3/cms": {
       "cms-package-dir": "{$vendor-dir}/typo3/cms",


### PR DESCRIPTION
Hi @einpraegsam ,
we added possibilities for delayed init of Ajax. To achieve this, we gave the Form a unique name "PowermailFormInstance", defined that as global instance, added a public function called externInitialize to call addAjaxFormSubmitListener() on a later time whenever / whereever it is needed. Also added new hidden input to hand over the id of Powermail form to the next stage of Ajax.

Also added a composer file to be able to install it from our fork to our project. Don't forget to change PunktDe to TYPO3-extensions !
Have a nice day